### PR TITLE
Update ReportGenerator

### DIFF
--- a/Tasks/PublishCodeCoverageResultsV1/make.json
+++ b/Tasks/PublishCodeCoverageResultsV1/make.json
@@ -17,7 +17,7 @@
     "externals": {
         "archivePackages": [
             {
-                "url": "https://github.com/danielpalme/ReportGenerator/releases/download/v4.0.15/ReportGenerator_4.0.15.zip",
+                "url": "https://github.com/danielpalme/ReportGenerator/releases/download/v4.1.5/ReportGenerator_4.1.5.zip",
                 "dest": "./"
             }
         ]


### PR DESCRIPTION
ReportGenerator is quite outdated.
Version 4.1.5 is the current release which includes some improvements:
https://github.com/danielpalme/ReportGenerator/releases/